### PR TITLE
[AML] deployment unittests

### DIFF
--- a/.ci/templates/unit-test-steps.yml
+++ b/.ci/templates/unit-test-steps.yml
@@ -12,7 +12,7 @@ steps:
   displayName: 'Create and activate conda environment'
 
 - script: |
-  az login --service-principal -u $(spidentity) -p $(spsecret) --tenant $(sptenant)
+    az login --service-principal -u $(spidentity) -p $(spsecret) --tenant $(sptenant)
 
 - bash: |
     echo $OSTYPE

--- a/.ci/templates/unit-test-steps.yml
+++ b/.ci/templates/unit-test-steps.yml
@@ -21,7 +21,7 @@ steps:
     echo $OSTYPE
     if [ ! -d .azureml ]; then  mkdir .azureml; fi;
     if [ ! -f .azureml/config.json ];
-    then echo -e "{\n    \"subscription_id\":\""$subscription_id"\",    \"resource_group\":\""$resource_group"\",    \"workspace_name\":\""$workspace_name"\",    \"location\":\""$location"\"\n}" > .azureml/config.json; fi;
+    then echo -e "{\n    \"subscription_id\":\""$subscriptionid"\",    \"resource_group\":\""$resourcegroup"\",    \"workspace_name\":\""$workspacename"\",    \"location\":\""$location"\"\n}" > .azureml/config.json; fi;
 
 - bash: |
     source activate cvbp
@@ -30,7 +30,7 @@ steps:
   displayName: 'Run Unit tests'
 
 - script: |
-    az ml workspace delete --all-resources --resource-group $(resource_group) --subscription-id $(subscription_id) --workspace-name $(workspace_name)
+    az ml workspace delete --all-resources --resource-group $(resourcegroup) --subscription-id $(subscriptionid) --workspace-name $(workspacename)
 
 - bash: |
       echo Remove Conda Environment

--- a/.ci/templates/unit-test-steps.yml
+++ b/.ci/templates/unit-test-steps.yml
@@ -14,6 +14,9 @@ steps:
 - script: |
     az login --service-principal -u $(spidentity) -p $(spsecret) --tenant $(sptenant)
 
+- script: |
+    az ml workspace create --workspace-name $(workspace_name) --application-insights --container-registry --storage-account --exist-ok --keyvault --resource-group $(resource_group)
+
 - bash: |
     echo $OSTYPE
     if [ ! -d .azureml ]; then  mkdir .azureml; fi;

--- a/.ci/templates/unit-test-steps.yml
+++ b/.ci/templates/unit-test-steps.yml
@@ -17,8 +17,8 @@ steps:
 - script: |
     az extension add --name azure-cli-ml
 
-- script: |
-    az ml workspace create --workspace-name $(workspacename) --exist-ok --resource-group $(resourcegroup)
+#- script: |
+#    az ml workspace create --workspace-name $(workspacename) --exist-ok --resource-group $(resourcegroup)
 
 - bash: |
     echo $OSTYPE

--- a/.ci/templates/unit-test-steps.yml
+++ b/.ci/templates/unit-test-steps.yml
@@ -27,7 +27,7 @@ steps:
     if [ -f .azureml/config.json ];
     then rm .azureml/config.json; fi;
     if [ ! -f .azureml/config.json ];
-    then echo -e "{\n    \"subscription_id\":\""$subscriptionid"\",    \"resource_group\":\""$resourcegroup"\",    \"workspace_name\":\""$workspacename"\",    \"location\":\""$location"\"\n}" > .azureml/config.json; fi;
+    then echo -e "{\n    \"subscription_id\":\"$(subscriptionid)\",    \"resource_group\":\"$(resourcegroup)\",    \"workspace_name\":\"$(workspacename)\",    \"location\":\"$(location)\"\n}" > .azureml/config.json; fi;
     cat .azureml/config.json
 
 - bash: |

--- a/.ci/templates/unit-test-steps.yml
+++ b/.ci/templates/unit-test-steps.yml
@@ -11,11 +11,23 @@ steps:
     conda env list  
   displayName: 'Create and activate conda environment'
 
+- script: |
+  az login --service-principal -u $(spidentity) -p $(spsecret) --tenant $(sptenant)
+
+- bash: |
+    echo $OSTYPE
+    if [ ! -d .azureml ]; then  mkdir .azureml; fi;
+    if [ ! -f .azureml/config.json ];
+    then echo -e "{\n    \"subscription_id\":\""$subscription_id"\",    \"resource_group\":\""$resource_group"\",    \"workspace_name\":\""$workspace_name"\",    \"location\":\""$location"\"\n}" > .azureml/config.json; fi;
+
 - bash: |
     source activate cvbp
     python -m ipykernel install --user --name cvbp --display-name "cvbp"
     pytest tests/unit --junitxml=junit/test-unitttest.xml
   displayName: 'Run Unit tests'
+
+- script: |
+    az ml workspace delete --all-resources --resource-group $(resource_group) --subscription-id $(subscription_id) --workspace-name $(workspace_name)
 
 - bash: |
       echo Remove Conda Environment

--- a/.ci/templates/unit-test-steps.yml
+++ b/.ci/templates/unit-test-steps.yml
@@ -17,8 +17,8 @@ steps:
 - script: |
     az extension add --name azure-cli-ml
 
-#- script: |
-#    az ml workspace create --workspace-name $(workspacename) --exist-ok --resource-group $(resourcegroup)
+- script: |
+    az ml workspace create --workspace-name $(workspacename) --exist-ok --resource-group $(resourcegroup)
 
 - bash: |
     echo $OSTYPE
@@ -36,8 +36,8 @@ steps:
     pytest tests/unit --junitxml=junit/test-unitttest.xml
   displayName: 'Run Unit tests'
 
-#- script: |
-#    az ml workspace delete --all-resources --resource-group $(resourcegroup) --subscription-id $(subscriptionid) --workspace-name $(workspacename)
+- script: |
+    az ml workspace delete --all-resources --resource-group $(resourcegroup) --subscription-id $(subscriptionid) --workspace-name $(workspacename)
 
 - bash: |
       echo Remove Conda Environment

--- a/.ci/templates/unit-test-steps.yml
+++ b/.ci/templates/unit-test-steps.yml
@@ -15,7 +15,7 @@ steps:
     az login --service-principal -u $(spidentity) -p $(spsecret) --tenant $(sptenant)
 
 - script: |
-    az ml workspace create --workspace-name $(workspace_name) --application-insights --container-registry --storage-account --exist-ok --keyvault --resource-group $(resource_group)
+    az ml workspace create --workspace-name $(workspacename) --application-insights --container-registry --storage-account --exist-ok --keyvault --resource-group $(resourcegroup)
 
 - bash: |
     echo $OSTYPE

--- a/.ci/templates/unit-test-steps.yml
+++ b/.ci/templates/unit-test-steps.yml
@@ -22,11 +22,13 @@ steps:
 
 - bash: |
     echo $OSTYPE
+    echo $workspacename
     if [ ! -d .azureml ]; then  mkdir .azureml; fi;
     if [ -f .azureml/config.json ];
     then rm .azureml/config.json; fi;
     if [ ! -f .azureml/config.json ];
     then echo -e "{\n    \"subscription_id\":\""$subscriptionid"\",    \"resource_group\":\""$resourcegroup"\",    \"workspace_name\":\""$workspacename"\",    \"location\":\""$location"\"\n}" > .azureml/config.json; fi;
+    cat .azureml/config.json
 
 - bash: |
     source activate cvbp

--- a/.ci/templates/unit-test-steps.yml
+++ b/.ci/templates/unit-test-steps.yml
@@ -18,7 +18,7 @@ steps:
     az extension add --name azure-cli-ml
 
 - script: |
-    az ml workspace create --workspace-name $(workspacename) --application-insights --container-registry --storage-account --exist-ok --keyvault --resource-group $(resourcegroup)
+    az ml workspace create --workspace-name $(workspacename) --exist-ok --resource-group $(resourcegroup)
 
 - bash: |
     echo $OSTYPE

--- a/.ci/templates/unit-test-steps.yml
+++ b/.ci/templates/unit-test-steps.yml
@@ -11,8 +11,8 @@ steps:
     conda env list  
   displayName: 'Create and activate conda environment'
 
-- bash: |
-    az login --service-principal -u $spidentity -p $spsecret --tenant $sptenant
+- script: |
+    az login --service-principal -u $(spidentity) -p $(spsecret) --tenant $(sptenant)
 
 - script: |
     az ml workspace create --workspace-name $(workspace_name) --application-insights --container-registry --storage-account --exist-ok --keyvault --resource-group $(resource_group)

--- a/.ci/templates/unit-test-steps.yml
+++ b/.ci/templates/unit-test-steps.yml
@@ -23,6 +23,8 @@ steps:
 - bash: |
     echo $OSTYPE
     if [ ! -d .azureml ]; then  mkdir .azureml; fi;
+    if [ -f .azureml/config.json ];
+    then rm .azureml/config.json; fi;
     if [ ! -f .azureml/config.json ];
     then echo -e "{\n    \"subscription_id\":\""$subscriptionid"\",    \"resource_group\":\""$resourcegroup"\",    \"workspace_name\":\""$workspacename"\",    \"location\":\""$location"\"\n}" > .azureml/config.json; fi;
 

--- a/.ci/templates/unit-test-steps.yml
+++ b/.ci/templates/unit-test-steps.yml
@@ -32,8 +32,8 @@ steps:
     pytest tests/unit --junitxml=junit/test-unitttest.xml
   displayName: 'Run Unit tests'
 
-- script: |
-    az ml workspace delete --all-resources --resource-group $(resourcegroup) --subscription-id $(subscriptionid) --workspace-name $(workspacename)
+#- script: |
+#    az ml workspace delete --all-resources --resource-group $(resourcegroup) --subscription-id $(subscriptionid) --workspace-name $(workspacename)
 
 - bash: |
       echo Remove Conda Environment

--- a/.ci/templates/unit-test-steps.yml
+++ b/.ci/templates/unit-test-steps.yml
@@ -15,6 +15,9 @@ steps:
     az login --service-principal -u $(spidentity) -p $(spsecret) --tenant $(sptenant)
 
 - script: |
+    az extension add --name azure-cli-ml
+
+- script: |
     az ml workspace create --workspace-name $(workspacename) --application-insights --container-registry --storage-account --exist-ok --keyvault --resource-group $(resourcegroup)
 
 - bash: |

--- a/.ci/templates/unit-test-steps.yml
+++ b/.ci/templates/unit-test-steps.yml
@@ -17,8 +17,8 @@ steps:
 - script: |
     az extension add --name azure-cli-ml
 
-- script: |
-    az ml workspace create --workspace-name $(workspacename) --exist-ok --resource-group $(resourcegroup)
+#- script: |
+#    az ml workspace create --workspace-name $(workspacename) --exist-ok --resource-group $(resourcegroup)
 
 - bash: |
     echo $OSTYPE
@@ -29,6 +29,7 @@ steps:
     if [ ! -f .azureml/config.json ];
     then echo -e "{\n    \"subscription_id\":\"$(subscriptionid)\",    \"resource_group\":\"$(resourcegroup)\",    \"workspace_name\":\"$(workspacename)\",    \"location\":\"$(location)\"\n}" > .azureml/config.json; fi;
     cat .azureml/config.json
+  displayName: 'Create workspace configuration file'
 
 - bash: |
     source activate cvbp
@@ -36,8 +37,8 @@ steps:
     pytest tests/unit --junitxml=junit/test-unitttest.xml
   displayName: 'Run Unit tests'
 
-- script: |
-    az ml workspace delete --all-resources --resource-group $(resourcegroup) --subscription-id $(subscriptionid) --workspace-name $(workspacename)
+#- script: |
+#    az ml workspace delete --all-resources --resource-group $(resourcegroup) --subscription-id $(subscriptionid) --workspace-name $(workspacename)
 
 - bash: |
       echo Remove Conda Environment

--- a/.ci/templates/unit-test-steps.yml
+++ b/.ci/templates/unit-test-steps.yml
@@ -11,8 +11,8 @@ steps:
     conda env list  
   displayName: 'Create and activate conda environment'
 
-- script: |
-    az login --service-principal -u $(spidentity) -p $(spsecret) --tenant $(sptenant)
+- bash: |
+    az login --service-principal -u $spidentity -p $spsecret --tenant $sptenant
 
 - script: |
     az ml workspace create --workspace-name $(workspace_name) --application-insights --container-registry --storage-account --exist-ok --keyvault --resource-group $(resource_group)

--- a/classification/notebooks/21_deployment_on_azure_container_instances.ipynb
+++ b/classification/notebooks/21_deployment_on_azure_container_instances.ipynb
@@ -640,7 +640,7 @@
     "# Create the Docker image\n",
     "try:\n",
     "    docker_image = ContainerImage.create(\n",
-    "        name = \"image-classif-resnet18-f48-2\",\n",
+    "        name = \"image-classif-resnet18-f48\",\n",
     "        models = [model],\n",
     "        image_config = image_config,\n",
     "        workspace = ws\n",

--- a/classification/notebooks/23_aci_aks_web_service_testing.ipynb
+++ b/classification/notebooks/23_aci_aks_web_service_testing.ipynb
@@ -23,7 +23,7 @@
     "1. [Service telemetry in Application Insights](#insights)\n",
     "1. [Clean up](#clean)\n",
     "  1. [Application Insights deactivation and web service termination](#del_app_insights)\n",
-    "  1. [Docker image deletion](#del_image)"
+    "  1. [Docker image and model deletion](#del_image)"
    ]
   },
   {
@@ -71,6 +71,7 @@
     "# Azure\n",
     "import azureml.core\n",
     "from azureml.core import Workspace\n",
+    "from azureml.core.model import Model\n",
     "\n",
     "# Computer Vision repository\n",
     "sys.path.extend([\".\", \"../..\"])\n",
@@ -458,9 +459,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 5.B Docker image deletion <a id=\"del_image\">\n",
+    "### 5.B Docker image and model deletion <a id=\"del_image\">\n",
     "\n",
-    "Now that the services no longer exist, we can delete the Docker image that we created in [21_deployment_on_azure_container_instances.ipynb](https://github.com/Microsoft/ComputerVisionBestPractices/blob/master/classification/notebooks/21_deployment_on_azure_container_instances.ipynb), and which contains our image classifier model."
+    "Now that the services no longer exist, we can delete the Docker image that we created in [21_deployment_on_azure_container_instances.ipynb](https://github.com/Microsoft/ComputerVisionBestPractices/blob/master/classification/notebooks/21_deployment_on_azure_container_instances.ipynb), and which contains our image classifier model, along with the model itself."
    ]
   },
   {
@@ -483,8 +484,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Retrieve the Docker image and delete it\n",
     "docker_image = ws.images[\"image-classif-resnet18-f48\"]\n",
     "docker_image.delete()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Retrieve all versions of the 'im_classif_resnet18' model and delete them\n",
+    "all_models = Model.list(workspace=ws)\n",
+    "relevant_models = [model for model in all_models if model.name == 'im_classif_resnet18']\n",
+    "for model in relevant_models:\n",
+    "    model.delete()"
    ]
   }
  ],

--- a/classification/notebooks/23_aci_aks_web_service_testing.ipynb
+++ b/classification/notebooks/23_aci_aks_web_service_testing.ipynb
@@ -442,14 +442,15 @@
    "outputs": [],
    "source": [
     "# Telemetry deactivation\n",
-    "# aks_service.update(enable_app_insights=False)\n",
+    "aks_service.update(enable_app_insights=False)\n",
+    "aci_service.update(enable_app_insights=False)\n",
     "\n",
     "# Services termination\n",
     "aci_service.delete()\n",
-    "# aks_service.delete()\n",
+    "aks_service.delete()\n",
     "\n",
     "# Compute target deletion\n",
-    "# aks_target.delete()"
+    "aks_target.delete()"
    ]
   },
   {
@@ -482,7 +483,7 @@
    "outputs": [],
    "source": [
     "docker_image = ws.images[\"image-classif-resnet18-f48\"]\n",
-    "# docker_image.delete()"
+    "docker_image.delete()"
    ]
   }
  ],

--- a/classification/notebooks/23_aci_aks_web_service_testing.ipynb
+++ b/classification/notebooks/23_aci_aks_web_service_testing.ipynb
@@ -450,6 +450,7 @@
     "aks_service.delete()\n",
     "\n",
     "# Compute target deletion\n",
+    "aks_target = ws.compute_targets['imgclass-aks-cpu']\n",
     "aks_target.delete()"
    ]
   },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,12 +53,18 @@ def classification_notebooks():
         "12_hard_negative_sampling": os.path.join(
             folder_notebooks, "12_hard_negative_sampling.ipynb"
         ),
+        "20_azure_workspace_setup": os.path.join(
+            folder_notebooks, "20_azure_workspace_setup.ipynb"
+        ),
         "21_deployment_on_azure_container_instances": os.path.join(
             folder_notebooks,
             "21_deployment_on_azure_container_instances.ipynb",
         ),
         "22_deployment_on_azure_kubernetes_service": os.path.join(
             folder_notebooks, "22_deployment_on_azure_kubernetes_service.ipynb"
+        ),
+        "23_aci_aks_web_service_testing": os.path.join(
+            folder_notebooks, "23_aci_aks_web_service_testing.ipynb"
         ),
     }
     return paths

--- a/tests/unit/classification/test_classification_notebooks.py
+++ b/tests/unit/classification/test_classification_notebooks.py
@@ -199,3 +199,21 @@ def test_22_notebook_run(classification_notebooks, tiny_ic_data_path):
         os.remove("output.ipynb")
     except OSError:
         pass
+
+
+@pytest.mark.notebooks
+def test_23_notebook_run(classification_notebooks, tiny_ic_data_path):
+    notebook_path = classification_notebooks["23_aci_aks_web_service_testing"]
+    pm.execute_notebook(
+        notebook_path,
+        OUTPUT_NOTEBOOK,
+        parameters=dict(
+            PM_VERSION=pm.__version__, DATA_PATH=tiny_ic_data_path
+        ),
+        kernel_name=KERNEL_NAME,
+    )
+
+    try:
+        os.remove("output.ipynb")
+    except OSError:
+        pass

--- a/tests/unit/classification/test_classification_notebooks.py
+++ b/tests/unit/classification/test_classification_notebooks.py
@@ -184,7 +184,7 @@ def test_21_notebook_run(classification_notebooks, tiny_ic_data_path):
 @pytest.mark.notebooks
 def test_22_notebook_run(classification_notebooks, tiny_ic_data_path):
     notebook_path = classification_notebooks[
-        "22_deployment_on_azure_container_instances"
+        "22_deployment_on_azure_kubernetes_service"
     ]
     pm.execute_notebook(
         notebook_path,

--- a/tests/unit/classification/test_classification_notebooks.py
+++ b/tests/unit/classification/test_classification_notebooks.py
@@ -126,9 +126,6 @@ OUTPUT_NOTEBOOK = "output.ipynb"
 
 @pytest.mark.notebooks
 def test_20_notebook_run(classification_notebooks):
-    """ NOTE - this function is intentionally prefixed with 'skip' so that
-    pytests bypasses this function
-    """
     notebook_path = classification_notebooks["20_azure_workspace_setup"]
     pm.execute_notebook(
         notebook_path,
@@ -145,9 +142,6 @@ def test_20_notebook_run(classification_notebooks):
 
 @pytest.mark.notebooks
 def test_21_notebook_run(classification_notebooks, tiny_ic_data_path):
-    """ NOTE - this function is intentionally prefixed with 'skip' so that
-    pytests bypasses this function
-    """
     notebook_path = classification_notebooks[
         "21_deployment_on_azure_container_instances"
     ]
@@ -168,10 +162,43 @@ def test_21_notebook_run(classification_notebooks, tiny_ic_data_path):
     except OSError:
         pass
 
-    # try:
-    #     os.remove("output.ipynb")
-    # except OSError:
-    #     pass
+    try:
+        os.remove("output.ipynb")
+    except OSError:
+        pass
+
+    # There should be only one file, but the name may be changed
+    file_list = glob.glob("./*.pkl")
+    for filePath in file_list:
+        try:
+            os.remove(filePath)
+        except OSError:
+            pass
+
+    # TODO should use temp folder for safe cleanup. Notebook should accept the folder paths via papermill param.
+    shutil.rmtree(os.path.join(os.getcwd(), "azureml-models"))
+    shutil.rmtree(os.path.join(os.getcwd(), "models"))
+    shutil.rmtree(os.path.join(os.getcwd(), "outputs"))
+
+
+@pytest.mark.notebooks
+def test_22_notebook_run(classification_notebooks, tiny_ic_data_path):
+    notebook_path = classification_notebooks[
+        "22_deployment_on_azure_container_instances"
+    ]
+    pm.execute_notebook(
+        notebook_path,
+        OUTPUT_NOTEBOOK,
+        parameters=dict(
+            PM_VERSION=pm.__version__, DATA_PATH=tiny_ic_data_path
+        ),
+        kernel_name=KERNEL_NAME,
+    )
+
+    try:
+        os.remove("output.ipynb")
+    except OSError:
+        pass
 
     # There should be only one file, but the name may be changed
     file_list = glob.glob("./*.pkl")

--- a/tests/unit/classification/test_classification_notebooks.py
+++ b/tests/unit/classification/test_classification_notebooks.py
@@ -6,11 +6,11 @@
 
 import os
 
-# import glob
+import glob
 import papermill as pm
 import pytest
 
-# import shutil
+import shutil
 
 # Unless manually modified, python3 should be
 # the name of the current jupyter kernel
@@ -19,15 +19,15 @@ KERNEL_NAME = "cvbp"
 OUTPUT_NOTEBOOK = "output.ipynb"
 
 
-@pytest.mark.notebooks
-def test_00_notebook_run(classification_notebooks):
-    notebook_path = classification_notebooks["00_webcam"]
-    pm.execute_notebook(
-        notebook_path,
-        OUTPUT_NOTEBOOK,
-        parameters=dict(PM_VERSION=pm.__version__),
-        kernel_name=KERNEL_NAME,
-    )
+# @pytest.mark.notebooks
+# def test_00_notebook_run(classification_notebooks):
+#     notebook_path = classification_notebooks["00_webcam"]
+#     pm.execute_notebook(
+#         notebook_path,
+#         OUTPUT_NOTEBOOK,
+#         parameters=dict(PM_VERSION=pm.__version__),
+#         kernel_name=KERNEL_NAME,
+#     )
 
 
 # @pytest.mark.notebooks
@@ -143,45 +143,45 @@ def test_20_notebook_run(classification_notebooks):
         pass
 
 
-# @pytest.mark.notebooks
-# def test_21_notebook_run(classification_notebooks, tiny_ic_data_path):
-#     """ NOTE - this function is intentionally prefixed with 'skip' so that
-#     pytests bypasses this function
-#     """
-#     notebook_path = classification_notebooks[
-#         "21_deployment_on_azure_container_instances"
-#     ]
-#     pm.execute_notebook(
-#         notebook_path,
-#         OUTPUT_NOTEBOOK,
-#         parameters=dict(
-#             PM_VERSION=pm.__version__, DATA_PATH=tiny_ic_data_path
-#         ),
-#         kernel_name=KERNEL_NAME,
-#     )
-#     try:
-#         os.remove("myenv.yml")
-#     except OSError:
-#         pass
-#     try:
-#         os.remove("score.py")
-#     except OSError:
-#         pass
-#
-#     try:
-#         os.remove("output.ipynb")
-#     except OSError:
-#         pass
-#
-#     # There should be only one file, but the name may be changed
-#     file_list = glob.glob("./*.pkl")
-#     for filePath in file_list:
-#         try:
-#             os.remove(filePath)
-#         except OSError:
-#             pass
-#
-#     # TODO should use temp folder for safe cleanup. Notebook should accept the folder paths via papermill param.
-#     shutil.rmtree(os.path.join(os.getcwd(), "azureml-models"))
-#     shutil.rmtree(os.path.join(os.getcwd(), "models"))
-#     shutil.rmtree(os.path.join(os.getcwd(), "outputs"))
+@pytest.mark.notebooks
+def test_21_notebook_run(classification_notebooks, tiny_ic_data_path):
+    """ NOTE - this function is intentionally prefixed with 'skip' so that
+    pytests bypasses this function
+    """
+    notebook_path = classification_notebooks[
+        "21_deployment_on_azure_container_instances"
+    ]
+    pm.execute_notebook(
+        notebook_path,
+        OUTPUT_NOTEBOOK,
+        parameters=dict(
+            PM_VERSION=pm.__version__, DATA_PATH=tiny_ic_data_path
+        ),
+        kernel_name=KERNEL_NAME,
+    )
+    try:
+        os.remove("myenv.yml")
+    except OSError:
+        pass
+    try:
+        os.remove("score.py")
+    except OSError:
+        pass
+
+    # try:
+    #     os.remove("output.ipynb")
+    # except OSError:
+    #     pass
+
+    # There should be only one file, but the name may be changed
+    file_list = glob.glob("./*.pkl")
+    for filePath in file_list:
+        try:
+            os.remove(filePath)
+        except OSError:
+            pass
+
+    # TODO should use temp folder for safe cleanup. Notebook should accept the folder paths via papermill param.
+    shutil.rmtree(os.path.join(os.getcwd(), "azureml-models"))
+    shutil.rmtree(os.path.join(os.getcwd(), "models"))
+    shutil.rmtree(os.path.join(os.getcwd(), "outputs"))

--- a/tests/unit/classification/test_classification_notebooks.py
+++ b/tests/unit/classification/test_classification_notebooks.py
@@ -5,10 +5,12 @@
 # https://github.com/Microsoft/Recommenders/tree/master/tests
 
 import os
-import glob
+
+# import glob
 import papermill as pm
 import pytest
-import shutil
+
+# import shutil
 
 # Unless manually modified, python3 should be
 # the name of the current jupyter kernel
@@ -28,139 +30,158 @@ def test_00_notebook_run(classification_notebooks):
     )
 
 
-@pytest.mark.notebooks
-def test_01_notebook_run(classification_notebooks, tiny_ic_data_path):
-    notebook_path = classification_notebooks["01_training_introduction"]
-    pm.execute_notebook(
-        notebook_path,
-        OUTPUT_NOTEBOOK,
-        parameters=dict(
-            PM_VERSION=pm.__version__, DATA_PATH=tiny_ic_data_path
-        ),
-        kernel_name=KERNEL_NAME,
-    )
+# @pytest.mark.notebooks
+# def test_01_notebook_run(classification_notebooks, tiny_ic_data_path):
+#     notebook_path = classification_notebooks["01_training_introduction"]
+#     pm.execute_notebook(
+#         notebook_path,
+#         OUTPUT_NOTEBOOK,
+#         parameters=dict(
+#             PM_VERSION=pm.__version__, DATA_PATH=tiny_ic_data_path
+#         ),
+#         kernel_name=KERNEL_NAME,
+#     )
+#
+#
+# @pytest.mark.notebooks
+# def test_02_notebook_run(
+#     classification_notebooks, tiny_multilabel_ic_data_path
+# ):
+#     notebook_path = classification_notebooks["02_multilabel_classification"]
+#     pm.execute_notebook(
+#         notebook_path,
+#         OUTPUT_NOTEBOOK,
+#         parameters=dict(
+#             PM_VERSION=pm.__version__, DATA_PATH=tiny_multilabel_ic_data_path
+#         ),
+#         kernel_name=KERNEL_NAME,
+#     )
+#
+#
+# @pytest.mark.notebooks
+# def test_03_notebook_run(classification_notebooks, tiny_ic_data_path):
+#     notebook_path = classification_notebooks["03_training_accuracy_vs_speed"]
+#     pm.execute_notebook(
+#         notebook_path,
+#         OUTPUT_NOTEBOOK,
+#         parameters=dict(
+#             PM_VERSION=pm.__version__,
+#             DATA_PATH=tiny_ic_data_path,
+#             MULTILABEL=False,
+#             MODEL_TYPE="fast_inference",  # options: ['fast_inference', 'high_performance', 'small_size']
+#             EPOCHS_HEAD=1,
+#             EPOCHS_BODY=1,
+#         ),
+#         kernel_name=KERNEL_NAME,
+#     )
+#
+#
+# @pytest.mark.notebooks
+# def test_10_notebook_run(classification_notebooks, tiny_ic_data_path):
+#     notebook_path = classification_notebooks["10_image_annotation"]
+#     pm.execute_notebook(
+#         notebook_path,
+#         OUTPUT_NOTEBOOK,
+#         parameters=dict(
+#             PM_VERSION=pm.__version__,
+#             IM_DIR=os.path.join(tiny_ic_data_path, "can"),
+#         ),
+#         kernel_name=KERNEL_NAME,
+#     )
+#
+#
+# @pytest.mark.notebooks
+# def test_11_notebook_run(classification_notebooks, tiny_ic_data_path):
+#     notebook_path = classification_notebooks["11_exploring_hyperparameters"]
+#     pm.execute_notebook(
+#         notebook_path,
+#         OUTPUT_NOTEBOOK,
+#         parameters=dict(
+#             PM_VERSION=pm.__version__,
+#             DATA=[tiny_ic_data_path],
+#             REPS=1,
+#             LEARNING_RATES=[1e-3],
+#             IM_SIZES=[199],
+#             EPOCHS=[1],
+#         ),
+#         kernel_name=KERNEL_NAME,
+#     )
+#
+#
+# @pytest.mark.notebooks
+# def test_12_notebook_run(classification_notebooks, tiny_ic_data_path):
+#     notebook_path = classification_notebooks["12_hard_negative_sampling"]
+#     pm.execute_notebook(
+#         notebook_path,
+#         OUTPUT_NOTEBOOK,
+#         parameters=dict(
+#             PM_VERSION=pm.__version__,
+#             DATA_PATH=tiny_ic_data_path,
+#             EPOCHS_HEAD=1,
+#             EPOCHS_BODY=1,
+#         ),
+#         kernel_name=KERNEL_NAME,
+#     )
 
 
 @pytest.mark.notebooks
-def test_02_notebook_run(
-    classification_notebooks, tiny_multilabel_ic_data_path
-):
-    notebook_path = classification_notebooks["02_multilabel_classification"]
-    pm.execute_notebook(
-        notebook_path,
-        OUTPUT_NOTEBOOK,
-        parameters=dict(
-            PM_VERSION=pm.__version__, DATA_PATH=tiny_multilabel_ic_data_path
-        ),
-        kernel_name=KERNEL_NAME,
-    )
-
-
-@pytest.mark.notebooks
-def test_03_notebook_run(classification_notebooks, tiny_ic_data_path):
-    notebook_path = classification_notebooks["03_training_accuracy_vs_speed"]
-    pm.execute_notebook(
-        notebook_path,
-        OUTPUT_NOTEBOOK,
-        parameters=dict(
-            PM_VERSION=pm.__version__,
-            DATA_PATH=tiny_ic_data_path,
-            MULTILABEL=False,
-            MODEL_TYPE="fast_inference",  # options: ['fast_inference', 'high_performance', 'small_size']
-            EPOCHS_HEAD=1,
-            EPOCHS_BODY=1,
-        ),
-        kernel_name=KERNEL_NAME,
-    )
-
-
-@pytest.mark.notebooks
-def test_10_notebook_run(classification_notebooks, tiny_ic_data_path):
-    notebook_path = classification_notebooks["10_image_annotation"]
-    pm.execute_notebook(
-        notebook_path,
-        OUTPUT_NOTEBOOK,
-        parameters=dict(
-            PM_VERSION=pm.__version__,
-            IM_DIR=os.path.join(tiny_ic_data_path, "can"),
-        ),
-        kernel_name=KERNEL_NAME,
-    )
-
-
-@pytest.mark.notebooks
-def test_11_notebook_run(classification_notebooks, tiny_ic_data_path):
-    notebook_path = classification_notebooks["11_exploring_hyperparameters"]
-    pm.execute_notebook(
-        notebook_path,
-        OUTPUT_NOTEBOOK,
-        parameters=dict(
-            PM_VERSION=pm.__version__,
-            DATA=[tiny_ic_data_path],
-            REPS=1,
-            LEARNING_RATES=[1e-3],
-            IM_SIZES=[199],
-            EPOCHS=[1],
-        ),
-        kernel_name=KERNEL_NAME,
-    )
-    
-    
-@pytest.mark.notebooks
-def test_12_notebook_run(classification_notebooks, tiny_ic_data_path):
-    notebook_path = classification_notebooks["12_hard_negative_sampling"]
-    pm.execute_notebook(
-        notebook_path,
-        OUTPUT_NOTEBOOK,
-        parameters=dict(
-            PM_VERSION=pm.__version__,
-            DATA_PATH=tiny_ic_data_path,
-            EPOCHS_HEAD=1,
-            EPOCHS_BODY=1,
-        ),
-        kernel_name=KERNEL_NAME,
-    )
-
-
-@pytest.mark.notebooks
-def skip_test_21_notebook_run(classification_notebooks, tiny_ic_data_path):
+def test_20_notebook_run(classification_notebooks):
     """ NOTE - this function is intentionally prefixed with 'skip' so that
     pytests bypasses this function
     """
-    notebook_path = classification_notebooks[
-        "21_deployment_on_azure_container_instances"
-    ]
+    notebook_path = classification_notebooks["20_azure_workspace_setup"]
     pm.execute_notebook(
         notebook_path,
         OUTPUT_NOTEBOOK,
-        parameters=dict(
-            PM_VERSION=pm.__version__, DATA_PATH=tiny_ic_data_path
-        ),
+        parameters=dict(PM_VERSION=pm.__version__),
         kernel_name=KERNEL_NAME,
     )
-    try:
-        os.remove("myenv.yml")
-    except OSError:
-        pass
-    try:
-        os.remove("score.py")
-    except OSError:
-        pass
 
     try:
         os.remove("output.ipynb")
     except OSError:
         pass
 
-    # There should be only one file, but the name may be changed
-    file_list = glob.glob("./*.pkl")
-    for filePath in file_list:
-        try:
-            os.remove(filePath)
-        except OSError:
-            pass
 
-    # TODO should use temp folder for safe cleanup. Notebook should accept the folder paths via papermill param.
-    shutil.rmtree(os.path.join(os.getcwd(), "azureml-models"))
-    shutil.rmtree(os.path.join(os.getcwd(), "models"))
-    shutil.rmtree(os.path.join(os.getcwd(), "outputs"))
+# @pytest.mark.notebooks
+# def test_21_notebook_run(classification_notebooks, tiny_ic_data_path):
+#     """ NOTE - this function is intentionally prefixed with 'skip' so that
+#     pytests bypasses this function
+#     """
+#     notebook_path = classification_notebooks[
+#         "21_deployment_on_azure_container_instances"
+#     ]
+#     pm.execute_notebook(
+#         notebook_path,
+#         OUTPUT_NOTEBOOK,
+#         parameters=dict(
+#             PM_VERSION=pm.__version__, DATA_PATH=tiny_ic_data_path
+#         ),
+#         kernel_name=KERNEL_NAME,
+#     )
+#     try:
+#         os.remove("myenv.yml")
+#     except OSError:
+#         pass
+#     try:
+#         os.remove("score.py")
+#     except OSError:
+#         pass
+#
+#     try:
+#         os.remove("output.ipynb")
+#     except OSError:
+#         pass
+#
+#     # There should be only one file, but the name may be changed
+#     file_list = glob.glob("./*.pkl")
+#     for filePath in file_list:
+#         try:
+#             os.remove(filePath)
+#         except OSError:
+#             pass
+#
+#     # TODO should use temp folder for safe cleanup. Notebook should accept the folder paths via papermill param.
+#     shutil.rmtree(os.path.join(os.getcwd(), "azureml-models"))
+#     shutil.rmtree(os.path.join(os.getcwd(), "models"))
+#     shutil.rmtree(os.path.join(os.getcwd(), "outputs"))

--- a/tests/unit/classification/test_classification_notebooks.py
+++ b/tests/unit/classification/test_classification_notebooks.py
@@ -199,16 +199,3 @@ def test_22_notebook_run(classification_notebooks, tiny_ic_data_path):
         os.remove("output.ipynb")
     except OSError:
         pass
-
-    # There should be only one file, but the name may be changed
-    file_list = glob.glob("./*.pkl")
-    for filePath in file_list:
-        try:
-            os.remove(filePath)
-        except OSError:
-            pass
-
-    # TODO should use temp folder for safe cleanup. Notebook should accept the folder paths via papermill param.
-    shutil.rmtree(os.path.join(os.getcwd(), "azureml-models"))
-    shutil.rmtree(os.path.join(os.getcwd(), "models"))
-    shutil.rmtree(os.path.join(os.getcwd(), "outputs"))

--- a/tests/unit/classification/test_classification_notebooks.py
+++ b/tests/unit/classification/test_classification_notebooks.py
@@ -19,109 +19,109 @@ KERNEL_NAME = "cvbp"
 OUTPUT_NOTEBOOK = "output.ipynb"
 
 
-# @pytest.mark.notebooks
-# def test_00_notebook_run(classification_notebooks):
-#     notebook_path = classification_notebooks["00_webcam"]
-#     pm.execute_notebook(
-#         notebook_path,
-#         OUTPUT_NOTEBOOK,
-#         parameters=dict(PM_VERSION=pm.__version__),
-#         kernel_name=KERNEL_NAME,
-#     )
+@pytest.mark.notebooks
+def test_00_notebook_run(classification_notebooks):
+    notebook_path = classification_notebooks["00_webcam"]
+    pm.execute_notebook(
+        notebook_path,
+        OUTPUT_NOTEBOOK,
+        parameters=dict(PM_VERSION=pm.__version__),
+        kernel_name=KERNEL_NAME,
+    )
 
 
-# @pytest.mark.notebooks
-# def test_01_notebook_run(classification_notebooks, tiny_ic_data_path):
-#     notebook_path = classification_notebooks["01_training_introduction"]
-#     pm.execute_notebook(
-#         notebook_path,
-#         OUTPUT_NOTEBOOK,
-#         parameters=dict(
-#             PM_VERSION=pm.__version__, DATA_PATH=tiny_ic_data_path
-#         ),
-#         kernel_name=KERNEL_NAME,
-#     )
-#
-#
-# @pytest.mark.notebooks
-# def test_02_notebook_run(
-#     classification_notebooks, tiny_multilabel_ic_data_path
-# ):
-#     notebook_path = classification_notebooks["02_multilabel_classification"]
-#     pm.execute_notebook(
-#         notebook_path,
-#         OUTPUT_NOTEBOOK,
-#         parameters=dict(
-#             PM_VERSION=pm.__version__, DATA_PATH=tiny_multilabel_ic_data_path
-#         ),
-#         kernel_name=KERNEL_NAME,
-#     )
-#
-#
-# @pytest.mark.notebooks
-# def test_03_notebook_run(classification_notebooks, tiny_ic_data_path):
-#     notebook_path = classification_notebooks["03_training_accuracy_vs_speed"]
-#     pm.execute_notebook(
-#         notebook_path,
-#         OUTPUT_NOTEBOOK,
-#         parameters=dict(
-#             PM_VERSION=pm.__version__,
-#             DATA_PATH=tiny_ic_data_path,
-#             MULTILABEL=False,
-#             MODEL_TYPE="fast_inference",  # options: ['fast_inference', 'high_performance', 'small_size']
-#             EPOCHS_HEAD=1,
-#             EPOCHS_BODY=1,
-#         ),
-#         kernel_name=KERNEL_NAME,
-#     )
-#
-#
-# @pytest.mark.notebooks
-# def test_10_notebook_run(classification_notebooks, tiny_ic_data_path):
-#     notebook_path = classification_notebooks["10_image_annotation"]
-#     pm.execute_notebook(
-#         notebook_path,
-#         OUTPUT_NOTEBOOK,
-#         parameters=dict(
-#             PM_VERSION=pm.__version__,
-#             IM_DIR=os.path.join(tiny_ic_data_path, "can"),
-#         ),
-#         kernel_name=KERNEL_NAME,
-#     )
-#
-#
-# @pytest.mark.notebooks
-# def test_11_notebook_run(classification_notebooks, tiny_ic_data_path):
-#     notebook_path = classification_notebooks["11_exploring_hyperparameters"]
-#     pm.execute_notebook(
-#         notebook_path,
-#         OUTPUT_NOTEBOOK,
-#         parameters=dict(
-#             PM_VERSION=pm.__version__,
-#             DATA=[tiny_ic_data_path],
-#             REPS=1,
-#             LEARNING_RATES=[1e-3],
-#             IM_SIZES=[199],
-#             EPOCHS=[1],
-#         ),
-#         kernel_name=KERNEL_NAME,
-#     )
-#
-#
-# @pytest.mark.notebooks
-# def test_12_notebook_run(classification_notebooks, tiny_ic_data_path):
-#     notebook_path = classification_notebooks["12_hard_negative_sampling"]
-#     pm.execute_notebook(
-#         notebook_path,
-#         OUTPUT_NOTEBOOK,
-#         parameters=dict(
-#             PM_VERSION=pm.__version__,
-#             DATA_PATH=tiny_ic_data_path,
-#             EPOCHS_HEAD=1,
-#             EPOCHS_BODY=1,
-#         ),
-#         kernel_name=KERNEL_NAME,
-#     )
+@pytest.mark.notebooks
+def test_01_notebook_run(classification_notebooks, tiny_ic_data_path):
+    notebook_path = classification_notebooks["01_training_introduction"]
+    pm.execute_notebook(
+        notebook_path,
+        OUTPUT_NOTEBOOK,
+        parameters=dict(
+            PM_VERSION=pm.__version__, DATA_PATH=tiny_ic_data_path
+        ),
+        kernel_name=KERNEL_NAME,
+    )
+
+
+@pytest.mark.notebooks
+def test_02_notebook_run(
+    classification_notebooks, tiny_multilabel_ic_data_path
+):
+    notebook_path = classification_notebooks["02_multilabel_classification"]
+    pm.execute_notebook(
+        notebook_path,
+        OUTPUT_NOTEBOOK,
+        parameters=dict(
+            PM_VERSION=pm.__version__, DATA_PATH=tiny_multilabel_ic_data_path
+        ),
+        kernel_name=KERNEL_NAME,
+    )
+
+
+@pytest.mark.notebooks
+def test_03_notebook_run(classification_notebooks, tiny_ic_data_path):
+    notebook_path = classification_notebooks["03_training_accuracy_vs_speed"]
+    pm.execute_notebook(
+        notebook_path,
+        OUTPUT_NOTEBOOK,
+        parameters=dict(
+            PM_VERSION=pm.__version__,
+            DATA_PATH=tiny_ic_data_path,
+            MULTILABEL=False,
+            MODEL_TYPE="fast_inference",  # options: ['fast_inference', 'high_performance', 'small_size']
+            EPOCHS_HEAD=1,
+            EPOCHS_BODY=1,
+        ),
+        kernel_name=KERNEL_NAME,
+    )
+
+
+@pytest.mark.notebooks
+def test_10_notebook_run(classification_notebooks, tiny_ic_data_path):
+    notebook_path = classification_notebooks["10_image_annotation"]
+    pm.execute_notebook(
+        notebook_path,
+        OUTPUT_NOTEBOOK,
+        parameters=dict(
+            PM_VERSION=pm.__version__,
+            IM_DIR=os.path.join(tiny_ic_data_path, "can"),
+        ),
+        kernel_name=KERNEL_NAME,
+    )
+
+
+@pytest.mark.notebooks
+def test_11_notebook_run(classification_notebooks, tiny_ic_data_path):
+    notebook_path = classification_notebooks["11_exploring_hyperparameters"]
+    pm.execute_notebook(
+        notebook_path,
+        OUTPUT_NOTEBOOK,
+        parameters=dict(
+            PM_VERSION=pm.__version__,
+            DATA=[tiny_ic_data_path],
+            REPS=1,
+            LEARNING_RATES=[1e-3],
+            IM_SIZES=[199],
+            EPOCHS=[1],
+        ),
+        kernel_name=KERNEL_NAME,
+    )
+
+
+@pytest.mark.notebooks
+def test_12_notebook_run(classification_notebooks, tiny_ic_data_path):
+    notebook_path = classification_notebooks["12_hard_negative_sampling"]
+    pm.execute_notebook(
+        notebook_path,
+        OUTPUT_NOTEBOOK,
+        parameters=dict(
+            PM_VERSION=pm.__version__,
+            DATA_PATH=tiny_ic_data_path,
+            EPOCHS_HEAD=1,
+            EPOCHS_BODY=1,
+        ),
+        kernel_name=KERNEL_NAME,
+    )
 
 
 @pytest.mark.notebooks


### PR DESCRIPTION
unit-test-steps.yml now contains the steps needed to run the AML notebook unit tests

Notes:
- the steps of creation and deletion of workspace are commented out because they are the right ones to run, but we currently get an "unable to create the workspace error" (likely a permission issue)
- the workspace name stored as an environment variable is "cvbp_unittes_ws" (I know, I forgot a "t" when creating the env var  :)  )
- Because of the issue mentioned above, this workspace was created manually, and doesn't get deleted at the end of the unittest run
- All the resources created by the notebooks 20 to 23 are deleted (i.e. models, Docker images, ACI and AKS web services, AKS cluster)
- I haven't had a chance to test on notebook # 24, but wanted to push a PR for this first, as it runs fine