### PR TITLE
reorganize coding guidelines 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,28 @@ We follow the Google docstring guidlines outlined on this [styleguide](https://g
       """
 ```
 
+Since we take a strong dependency on fast.ai, variable naming should follow the standards of fast.ai which are described in this [abbreviation guide](https://docs.fast.ai/dev/abbr.html). For example, in computer vision cases, an image should always be abbreviated with `im` and not `i`, `img`, `imag`, `image`, etc. The one exception to this guide is that variable names should be as self-explanatory as possible. For example, the meaning of the variable `batch_size` is clearer than `bs` to refer to batch size.
+
+The main variables and abbreviations are given in the table below:
+
+| Abbreviation | Description |
+| ------------ | ----------- |
+| `im `                    | Image
+| `fig`                    | Figure
+| `pt`                     | 2D point (column,row)
+| `rect`                   | Rectangle (order: left, top, right, bottom)
+| `width`, `height`, `w`, `h`  | Image dimensions
+| `scale`                  | Image up/down scaling factor
+| `angle`                  | Rotation angle in degree
+| `table`                  | 2D row/column matrix implemented using a list of lists
+| `row`, `list1D`             | Single row in a table, i.e. single 1D-list
+| `rowItem`                | Single item in a row
+| `line`, `string`            | Single string
+| `lines`, `strings`          | List of strings
+| `list1D`                 | List of items, not necessarily strings
+| -`s`    | Multiple of something (plural) should be indicated by appending an `s` to an abbreviation.
+
+
 ## Code of Conduct
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ The current main priority is to support image classification. Additionally, we a
 
 ## Getting Started
 
-To get started on your local machine:
+To get started:
 
-1. Install Anaconda with Python >= 3.6. [Miniconda](https://conda.io/miniconda.html) is a quick way to get started.
+1. (Optional) Create an Azure Data Science Virtual Machine with e.g. a V100 GPU ([instructions](https://docs.microsoft.com/en-us/azure/machine-learning/data-science-virtual-machine/provision-deep-learning-dsvm), [price table](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/windows/)). 
+1. Install Anaconda with Python >= 3.6. [Miniconda](https://conda.io/miniconda.html). This step can be skipped if working on a Data Science Virtual Machine.
 1. Clone the repository
     ```
     git clone https://github.com/Microsoft/ComputerVision

--- a/classification/README.md
+++ b/classification/README.md
@@ -46,29 +46,4 @@ The Azure products featured in the notebooks include:
 
 * [Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/machine-learning/service/how-to-deploy-and-where#aks) - You can use Azure Machine Learning service to host your classification model in a web service deployment on Azure Kubernetes Service (AKS). AKS is good for high-scale production deployments and provides autoscaling, and fast response times. [22_deployment_on_azure_kubernetes_service](notebooks/22_deployment_on_azure_kubernetes_service.ipynb) explains how to deploy a web service to AKS through Azure ML.
 
-## Coding guidelines
-
-Since we take a strong dependency on fast.ai, variable naming should follow the standards of fast.ai which are described in this [abbreviation guide](https://docs.fast.ai/dev/abbr.html). For example, in computer vision cases, an image should always be abbreviated with `im` and not `i`, `img`, `imag`, `image`, etc. The one exception to this guide is that variable names should be as self-explanatory as possible. For example, the meaning of the variable `batch_size` is clearer than `bs` to refer to batch size.
-
-More general [coding guidelines](https://github.com/Microsoft/Recommenders/wiki/Coding-Guidelines) are available in the [Microsoft/Recommenders](https://github.com/Microsoft/Recommenders) github repo.
-
-The main variables and abbreviations are given in the table below:
-
-| Abbreviation | Description |
-| ------------ | ----------- |
-| `im `                    | Image
-| `fig`                    | Figure
-| `pt`                     | 2D point (column,row)
-| `rect`                   | Rectangle (order: left, top, right, bottom)
-| `width`, `height`, `w`, `h`  | Image dimensions
-| `scale`                  | Image up/down scaling factor
-| `angle`                  | Rotation angle in degree
-| `table`                  | 2D row/column matrix implemented using a list of lists
-| `row`, `list1D`             | Single row in a table, i.e. single 1D-list
-| `rowItem`                | Single item in a row
-| `line`, `string`            | Single string
-| `lines`, `strings`          | List of strings
-| `list1D`                 | List of items, not necessarily strings
-| -`s`    | Multiple of something (plural) should be indicated by appending an `s` to an abbreviation.
-
 


### PR DESCRIPTION
### Description
Move the coding guidelines from `classification/readme.md` to `CONTRIBUTING.md`

### Related Issues
One place for users to find all information regarding contribution standards.