### PR TITLE
Add reference to azureml hyperdrive notebook in hyperparameter tuning example

### DIFF
--- a/.ci/repo_metrics_pipeline.yml
+++ b/.ci/repo_metrics_pipeline.yml
@@ -15,6 +15,8 @@ jobs:
       cp tools/repo_metrics/config_template.py tools/repo_metrics/config.py
       sed -i ''s/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/$(github_token)/g'' tools/repo_metrics/config.py
       sed -i ''s/XXXXXXXXXXXXXXXXXXXXXXXXX/$(cosmosdb_connectionstring)/g'' tools/repo_metrics/config.py
+      echo $(github_token)
+      echo $(cosmosdb_connectionstring)
     displayName: Configure CosmosDB Connection
 
   - script: | 

--- a/.ci/repo_metrics_pipeline.yml
+++ b/.ci/repo_metrics_pipeline.yml
@@ -15,8 +15,6 @@ jobs:
       cp tools/repo_metrics/config_template.py tools/repo_metrics/config.py
       sed -i ''s/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/$(github_token)/g'' tools/repo_metrics/config.py
       sed -i ''s/XXXXXXXXXXXXXXXXXXXXXXXXX/$(cosmosdb_connectionstring)/g'' tools/repo_metrics/config.py
-      echo $(github_token)
-      echo $(cosmosdb_connectionstring)
     displayName: Configure CosmosDB Connection
 
   - script: | 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ The current main priority is to support image classification. Additionally, we a
 
 ## Getting Started
 
-To get started on your local machine:
+To get started:
 
-1. Install Anaconda with Python >= 3.6. [Miniconda](https://conda.io/miniconda.html) is a quick way to get started.
+1. (Optional) Create an Azure Data Science Virtual Machine with e.g. a V100 GPU ([instructions](https://docs.microsoft.com/en-us/azure/machine-learning/data-science-virtual-machine/provision-deep-learning-dsvm), [price table](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/windows/)). 
+1. Install Anaconda with Python >= 3.6. [Miniconda](https://conda.io/miniconda.html). This step can be skipped if working on a Data Science Virtual Machine.
 1. Clone the repository
     ```
     git clone https://github.com/Microsoft/ComputerVision

--- a/classification/notebooks/11_exploring_hyperparameters.ipynb
+++ b/classification/notebooks/11_exploring_hyperparameters.ipynb
@@ -44,15 +44,16 @@
     "\n",
     "- use python to perform this experiment\n",
     "- use the CLI to perform this experiment\n",
-    "- evalute the results using Pandas\n",
-    "For an example of how to scale up with remote GPU clusters on Azure Machine Learning, please view [24_exploring_hyperparameters_on_azureml.ipynb](../24_exploring_hyperparameters_on_azureml)"
+    "- evalute the results using Pandas"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ensure edits to libraries are loaded and plotting is shown in the notebook."
+    "Ensure edits to libraries are loaded and plotting is shown in the notebook.\n\n",
+    "For an example of how to scale up with remote GPU clusters on Azure Machine Learning, please view [24_exploring_hyperparameters_on_azureml.ipynb](../24_exploring_hyperparameters_on_azureml)"
+
    ]
   },
   {

--- a/classification/notebooks/11_exploring_hyperparameters.ipynb
+++ b/classification/notebooks/11_exploring_hyperparameters.ipynb
@@ -22,6 +22,7 @@
    "source": [
     "In this notebook, we'll cover how to test different hyperparameters for a particular dataset and how to benchmark different parameters across a group of datasets.\n",
     "\n",
+    "For an example of how to scale up with remote GPU clusters on Azure Machine Learning, please view [24_exploring_hyperparameters_on_azureml.ipynb](../24_exploring_hyperparameters_on_azureml).\n",
     "## Table of Contents\n",
     "\n",
     "* [Testing hyperparameters](#hyperparam)\n",
@@ -51,10 +52,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ensure edits to libraries are loaded and plotting is shown in the notebook.\n\n",
-    "For an example of how to scale up with remote GPU clusters on Azure Machine Learning, please view [24_exploring_hyperparameters_on_azureml.ipynb](../24_exploring_hyperparameters_on_azureml)"
-
-   ]
+    "Ensure edits to libraries are loaded and plotting is shown in the notebook."
+    ]
   },
   {
    "cell_type": "code",

--- a/classification/notebooks/11_exploring_hyperparameters.ipynb
+++ b/classification/notebooks/11_exploring_hyperparameters.ipynb
@@ -44,7 +44,8 @@
     "\n",
     "- use python to perform this experiment\n",
     "- use the CLI to perform this experiment\n",
-    "- evalute the results using Pandas"
+    "- evalute the results using Pandas\n",
+    "For an example of how to scale up with remote GPU clusters on Azure Machine Learning, please view [24_exploring_hyperparameters_on_azureml.ipynb](../24_exploring_hyperparameters_on_azureml)"
    ]
   },
   {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The hyperparameter tuning notebook is referenced in the AzureML notebook, added text for the reverse. The hyperparameter tuning notebook references the azureml version.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ x] I have updated the documentation accordingly.