### PR TITLE
Fix bug with conda env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,6 +27,7 @@ dependencies:
 - bqplot
 - scikit-learn>=0.19.1
 - pip>=19.0.3
+- cython>=0.29.1
 - pip:
   - azureml-sdk[notebooks,contrib]>=1.0.30
   - black>=18.6b4


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

All tests were breaking:


```
Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
Collecting azureml-sdk[contrib,notebooks]>=1.0.30 (from -r /data/home/cvbpuser/myagent/_work/1/s/condaenv.6UVNCa.requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/c5/95/4062861d1a406be7bb8dc00378930ec660d08856b75cad1740f8dc29d4be/azureml_sdk-1.0.60-py3-none-any.whl
Collecting black>=18.6b4 (from -r /data/home/cvbpuser/myagent/_work/1/s/condaenv.6UVNCa.requirements.txt (line 2))
  Using cached https://files.pythonhosted.org/packages/30/62/cf549544a5fe990bbaeca21e9c419501b2de7a701ab0afb377bc81676600/black-19.3b0-py36-none-any.whl
Collecting papermill>=0.15.0 (from -r /data/home/cvbpuser/myagent/_work/1/s/condaenv.6UVNCa.requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/de/f1/bc349008ddd34f093defabb05b3405b244ebac2ee9aa1d53bc1546a9deeb/papermill-1.1.0-py2.py3-none-any.whl
Collecting ipywebrtc (from -r /data/home/cvbpuser/myagent/_work/1/s/condaenv.6UVNCa.requirements.txt (line 4))
  Using cached https://files.pythonhosted.org/packages/65/6b/b78b2b6f96fb2299eebae3083d3625cedb62a35ddc9815897f25c8093edd/ipywebrtc-0.5.0-py2.py3-none-any.whl
Collecting nvidia-ml-py3 (from -r /data/home/cvbpuser/myagent/_work/1/s/condaenv.6UVNCa.requirements.txt (line 5))
Collecting pre-commit>=1.14.4 (from -r /data/home/cvbpuser/myagent/_work/1/s/condaenv.6UVNCa.requirements.txt (line 6))
  Using cached https://files.pythonhosted.org/packages/5b/e2/70050edecec542122bd32789b2c4563d578e0152c0f338f7870b7627afeb/pre_commit-1.18.3-py2.py3-none-any.whl
Collecting nteract-scrapbook (from -r /data/home/cvbpuser/myagent/_work/1/s/condaenv.6UVNCa.requirements.txt (line 7))
  Using cached https://files.pythonhosted.org/packages/1a/85/05460941cf6f07bce751b566f93c7f90d169681826109915c513c07289f5/nteract_scrapbook-0.3.1-py2.py3-none-any.whl
Collecting pycocotools from git+https://github.com/philferriere/cocoapi.git#egg=pycocotools&subdirectory=PythonAPI (from -r /data/home/cvbpuser/myagent/_work/1/s/condaenv.6UVNCa.requirements.txt (line 8))
  Cloning https://github.com/philferriere/cocoapi.git to /tmp/pip-install-c8lx7dp0/pycocotools
  Running command git clone -q https://github.com/philferriere/cocoapi.git /tmp/pip-install-c8lx7dp0/pycocotools
    ERROR: Command errored out with exit status 1:
     command: /data/anaconda/envs/cv/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-c8lx7dp0/pycocotools/PythonAPI/setup.py'"'"'; __file__='"'"'/tmp/pip-install-c8lx7dp0/pycocotools/PythonAPI/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base pip-egg-info
         cwd: /tmp/pip-install-c8lx7dp0/pycocotools/PythonAPI
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-c8lx7dp0/pycocotools/PythonAPI/setup.py", line 2, in <module>
        from Cython.Build import cythonize
    ModuleNotFoundError: No module named 'Cython'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.

CondaValueError: pip returned an error
```

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.