### PR TITLE
changed so that label_idx 0 is never used

### DIFF
--- a/utils_cv/detection/dataset.py
+++ b/utils_cv/detection/dataset.py
@@ -162,6 +162,7 @@ class DetectionDataset:
             collate_fn=collate_fn,
         )
 
+
     def _read_annos(self) -> List[str]:
         """ Parses all Pascal VOC formatted annotation files to extract all
         possible labels. """
@@ -203,7 +204,7 @@ class DetectionDataset:
             self.anno_bboxes.append(anno_bboxes)
 
         # Get list of all labels
-        labels = ["__background__"]
+        labels = [] #["__background__"]
         for anno_bboxes in self.anno_bboxes:
             for anno_bbox in anno_bboxes:
                 labels.append(anno_bbox.label_name)
@@ -212,7 +213,8 @@ class DetectionDataset:
         # Set for each bounding box label name also what its integer representation is
         for anno_bboxes in self.anno_bboxes:
             for anno_bbox in anno_bboxes:
-                anno_bbox.label_idx = self.labels.index(anno_bbox.label_name)
+                anno_bbox.label_idx = self.labels.index(anno_bbox.label_name) +1
+                
 
     def split_train_test(
         self, train_pct: float = 0.8

--- a/utils_cv/detection/dataset.py
+++ b/utils_cv/detection/dataset.py
@@ -162,7 +162,6 @@ class DetectionDataset:
             collate_fn=collate_fn,
         )
 
-
     def _read_annos(self) -> List[str]:
         """ Parses all Pascal VOC formatted annotation files to extract all
         possible labels. """
@@ -204,7 +203,7 @@ class DetectionDataset:
             self.anno_bboxes.append(anno_bboxes)
 
         # Get list of all labels
-        labels = [] #["__background__"]
+        labels = []
         for anno_bboxes in self.anno_bboxes:
             for anno_bbox in anno_bboxes:
                 labels.append(anno_bbox.label_name)
@@ -213,8 +212,7 @@ class DetectionDataset:
         # Set for each bounding box label name also what its integer representation is
         for anno_bboxes in self.anno_bboxes:
             for anno_bbox in anno_bboxes:
-                anno_bbox.label_idx = self.labels.index(anno_bbox.label_name) +1
-                
+                anno_bbox.label_idx = self.labels.index(anno_bbox.label_name) +1   
 
     def split_train_test(
         self, train_pct: float = 0.8

--- a/utils_cv/detection/model.py
+++ b/utils_cv/detection/model.py
@@ -42,7 +42,7 @@ def _get_det_bboxes(
 
     det_bboxes = []
     for label, box, score in zip(pred_labels, pred_boxes, pred_scores):
-        label_name = labels[label]
+        label_name = labels[label-1]
         det_bbox = DetectionBbox.from_array(
             box,
             score=score,
@@ -151,7 +151,7 @@ class DetectionLearner:
 
         # setup model, default to fasterrcnn
         if self.model is None:
-            self.model = get_pretrained_fasterrcnn(len(dataset.labels))
+            self.model = get_pretrained_fasterrcnn(len(dataset.labels)+1)
         self.model.to(self.device)
 
     def __getattr__(self, attr):


### PR DESCRIPTION
Fixed bug with one class never being found since the labels need to start from 1 (label 0 is reserved for background).

The 01 notebook runs without any changes and now produces near perfect mAP for both training and test sets. I did not run the other notebooks.