### PR TITLE
Fixed conda environment.yaml file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -36,5 +36,4 @@ dependencies:
 - pyyaml>=5.1.2
 - requests>=2.22.0
 - pip:
-#  - azureml-sdk[notebooks,contrib]>=1.0.30
   - nteract-scrapbook

--- a/environment.yml
+++ b/environment.yml
@@ -31,12 +31,12 @@ dependencies:
 - black>=18.6b4
 - ipywebrtc 
 - lxml>=4.3.2
-- nvidia-ml-py3
 - pre-commit>=1.14.4
 - pyyaml>=5.1.2
 - requests>=2.22.0
 - cython
 - pip:
+  - nvidia-ml-py3
   - nteract-scrapbook
   - azureml-sdk[notebooks,contrib]>=1.0.30
   - git+https://github.com/philferriere/cocoapi.git#egg=pycocotools&subdirectory=PythonAPI

--- a/environment.yml
+++ b/environment.yml
@@ -38,3 +38,4 @@ dependencies:
 - pip:
   - nteract-scrapbook
   - azureml-sdk[notebooks,contrib]>=1.0.30
+  - git+https://github.com/philferriere/cocoapi.git#egg=pycocotools^&subdirectory=PythonAPI

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,6 @@ dependencies:
 - python==3.6.8
 - pytorch>=1.2.0
 - torchvision>=0.3.0
-- pycocotools>=2.0
 - fastai==1.0.57
 - ipykernel>=4.6.1
 - jupyter>=1.0.0
@@ -28,15 +27,14 @@ dependencies:
 - scikit-learn>=0.19.1
 - pip>=19.0.3
 - cython>=0.29.1
+- papermill>=0.15.0
+- black>=18.6b4
+- ipywebrtc 
+- lxml>=4.3.2
+- nvidia-ml-py3
+- pre-commit>=1.14.4
+- pyyaml>=5.1.2
+- requests>=2.22.0
 - pip:
   - azureml-sdk[notebooks,contrib]>=1.0.30
-  - black>=18.6b4
-  - papermill>=0.15.0
-  - ipywebrtc
-  - nvidia-ml-py3
-  - pre-commit>=1.14.4
   - nteract-scrapbook
-  # - git+https://github.com/philferriere/cocoapi.git#egg=pycocotools&subdirectory=PythonAPI
-  - pyyaml>=5.1.2
-  - lxml>=4.3.2
-  - requests>=2.22.0

--- a/environment.yml
+++ b/environment.yml
@@ -37,3 +37,4 @@ dependencies:
 - requests>=2.22.0
 - pip:
   - nteract-scrapbook
+  - azureml-sdk[notebooks,contrib]>=1.0.30

--- a/environment.yml
+++ b/environment.yml
@@ -35,6 +35,7 @@ dependencies:
 - pre-commit>=1.14.4
 - pyyaml>=5.1.2
 - requests>=2.22.0
+- cython
 - pip:
   - nteract-scrapbook
   - azureml-sdk[notebooks,contrib]>=1.0.30

--- a/environment.yml
+++ b/environment.yml
@@ -36,5 +36,5 @@ dependencies:
 - pyyaml>=5.1.2
 - requests>=2.22.0
 - pip:
-  - azureml-sdk[notebooks,contrib]>=1.0.30
+#  - azureml-sdk[notebooks,contrib]>=1.0.30
   - nteract-scrapbook

--- a/environment.yml
+++ b/environment.yml
@@ -39,4 +39,4 @@ dependencies:
 - pip:
   - nteract-scrapbook
   - azureml-sdk[notebooks,contrib]>=1.0.30
-  - git+https://github.com/philferriere/cocoapi.git#egg=pycocotools^&subdirectory=PythonAPI
+  - git+https://github.com/philferriere/cocoapi.git#egg=pycocotools&subdirectory=PythonAPI


### PR DESCRIPTION
Fixed environment.yaml file. Tested and runs on Linux and Windows, both CPU and GPU.

The order within the pip section was important. E.g. nteract-scrapbook had to be before azureml-sdk. Also moved as much as possible to conda. The nvidia-ml-py3 library could be in the conda section, and the tests did run successfully and at the same speed, but there was a warning thrown that fast.ai claims it cannot find it.

@jiata: Looks like this one environment.yml file should work for object detection on both Linux and Windows.
@miguelgfierro: you probably might want to use the same .yml file also in master, I guess it will solve some of the problems. The .yml file in master used to work, but I guess because of updated libraries it stopped.