### PR TITLE
Read floating point coordinate from text instead of integer

### DIFF
--- a/utils_cv/detection/dataset.py
+++ b/utils_cv/detection/dataset.py
@@ -73,10 +73,10 @@ def parse_pascal_voc_anno(
     for obj in objs:
         label = obj.find("name").text
         bnd_box = obj.find("bndbox")
-        left = int(bnd_box[0].text)
-        top = int(bnd_box[1].text)
-        right = int(bnd_box[2].text)
-        bottom = int(bnd_box[3].text)
+        left = float(bnd_box[0].text)
+        top = float(bnd_box[1].text)
+        right = float(bnd_box[2].text)
+        bottom = float(bnd_box[3].text)
 
         # Set mapping of label name to label index
         if labels is None:


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Changed the parsed coordinates from integer to float.

Some PASCAL VOC annotations (reported by Mirco) give coordinates of floating point which fails the conversion from text to integer by using `int(str)` in the function `parse_pascal_voc_anno()`  in `utils_cv/detection/dataset.py`.  And in `PIL.ImageDraw`, floating point coordinates works fine, so using floating point will include more use cases.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.