### PR TITLE
matplotlib switch backend

### DIFF
--- a/detection/notebooks/00_webcam.ipynb
+++ b/detection/notebooks/00_webcam.ipynb
@@ -40,17 +40,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%reload_ext autoreload\n",
-    "%autoreload 2\n",
-    "%matplotlib inline"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
    "outputs": [
@@ -86,13 +75,35 @@
     "# utils_cv\n",
     "sys.path.append(\"../../\")\n",
     "from utils_cv.common.data import data_path\n",
-    "from utils_cv.common.gpu import which_processor\n",
+    "from utils_cv.common.gpu import which_processor, is_windows\n",
     "from utils_cv.detection.data import coco_labels\n",
     "from utils_cv.detection.model import _get_det_bboxes\n",
     "from utils_cv.detection.plot import PlotSettings, plot_boxes\n",
     "\n",
+    "# Change matplotlib backend so that plots are shown for windows\n",
+    "if is_windows():\n",
+    "    plt.switch_backend('TkAgg')\n",
+    "\n",
     "print(f\"TorchVision: {torchvision.__version__}\")\n",
     "which_processor()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This shows your machine's GPUs (if it has any) and the computing device `torch/torchvision` is using."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%reload_ext autoreload\n",
+    "%autoreload 2\n",
+    "%matplotlib inline"
    ]
   },
   {

--- a/detection/notebooks/01_training_introduction.ipynb
+++ b/detection/notebooks/01_training_introduction.ipynb
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "scrolled": true
    },
@@ -40,6 +40,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "TorchVision: 0.4.0a0\n",
       "Torch is using GPU: Tesla V100-PCIE-16GB\n"
      ]
     }
@@ -58,6 +59,7 @@
     "from random import randrange\n",
     "from typing import Tuple\n",
     "import torch\n",
+    "import torchvision\n",
     "from torchvision import transforms\n",
     "import scrapbook as sb\n",
     "\n",
@@ -79,6 +81,7 @@
     "if is_windows():\n",
     "    plt.switch_backend('TkAgg')\n",
     "\n",
+    "print(f\"TorchVision: {torchvision.__version__}\")\n",
     "which_processor()"
    ]
   },
@@ -86,7 +89,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This shows your machine's GPUs (if has any) and the computing device `torch/torchvision` is using."
+    "This shows your machine's GPUs (if it has any) and the computing device `torch/torchvision` is using."
    ]
   },
   {


### PR DESCRIPTION
fixes this:

"
On windows VM, matplotlib is using wrong backend and hence not showing any plots in notebooks. Not sure why, could fix *but not nice) by adding new cell under imports in EACH notebook with: 
```
import matplotlib 
matplotlib.pyplot.switch_backend('TkAgg') 
%matplotlib inline 
```
"

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
- [x] I have updated the documentation accordingly.