### PR TITLE
Correct unzipped file dest folder to unzipped_dir

### DIFF
--- a/scenarios/classification/01_training_introduction.ipynb
+++ b/scenarios/classification/01_training_introduction.ipynb
@@ -104,7 +104,7 @@
    },
    "outputs": [],
    "source": [
-    "DATA_PATH     = unzip_url(Urls.fridge_objects_path, exist_ok=True)\n",
+    "DATA_PATH     = str(Path(unzip_url(Urls.fridge_objects_path, exist_ok=True)) / \"fridgeObjects\")\n",
     "EPOCHS        = 10\n",
     "LEARNING_RATE = 1e-4\n",
     "IM_SIZE       = 300\n",

--- a/scenarios/classification/02_multilabel_classification.ipynb
+++ b/scenarios/classification/02_multilabel_classification.ipynb
@@ -103,7 +103,7 @@
    },
    "outputs": [],
    "source": [
-    "DATA_PATH     = unzip_url(Urls.multilabel_fridge_objects_path, exist_ok=True)\n",
+    "DATA_PATH     = str(Path(unzip_url(Urls.multilabel_fridge_objects_path, exist_ok=True)) / \"multilabelFridgeObjects\")\n",
     "EPOCHS        = 10\n",
     "LEARNING_RATE = 1e-4\n",
     "IM_SIZE       = 300\n",

--- a/scenarios/classification/03_training_accuracy_vs_speed.ipynb
+++ b/scenarios/classification/03_training_accuracy_vs_speed.ipynb
@@ -177,7 +177,7 @@
     "MODEL_TYPE = \"fast_inference\"\n",
     "\n",
     "# Path to your data\n",
-    "DATA_PATH = unzip_url(Urls.fridge_objects_path, exist_ok=True)\n",
+    "DATA_PATH = str(Path(unzip_url(Urls.fridge_objects_path, exist_ok=True)) / \"fridgeObjects\")\n",
     "\n",
     "# Epochs to train for\n",
     "EPOCHS_HEAD = 4\n",

--- a/scenarios/classification/10_image_annotation.ipynb
+++ b/scenarios/classification/10_image_annotation.ipynb
@@ -81,7 +81,7 @@
     }
    ],
    "source": [
-    "IM_DIR = os.path.join((unzip_url(Urls.fridge_objects_tiny_path, exist_ok=True)), 'can')\n",
+    "IM_DIR = os.path.join(str(Path(unzip_url(Urls.fridge_objects_tiny_path, exist_ok=True)) / \"fridgeObjectsTiny\"), 'can')\n",
     "ANNO_PATH = \"cvbp_ic_annotation.txt\"\n",
     "print(f\"Using images in directory: {IM_DIR}.\")"
    ]

--- a/scenarios/classification/11_exploring_hyperparameters.ipynb
+++ b/scenarios/classification/11_exploring_hyperparameters.ipynb
@@ -120,7 +120,7 @@
    },
    "outputs": [],
    "source": [
-    "DATA = [unzip_url(Urls.fridge_objects_path, exist_ok=True), unzip_url(Urls.fridge_objects_watermark_path, exist_ok=True)]\n",
+    "DATA = [str(Path(unzip_url(Urls.fridge_objects_path, exist_ok=True)) / \"fridgeObjects\"), str(Path(unzip_url(Urls.fridge_objects_watermark_path, exist_ok=True)) / \"fridgeObjectsWatermark\")]\n",
     "REPS = 3\n",
     "LEARNING_RATES = [1e-3, 1e-4, 1e-5]\n",
     "IM_SIZES = [299, 499]\n",

--- a/scenarios/classification/12_hard_negative_sampling.ipynb
+++ b/scenarios/classification/12_hard_negative_sampling.ipynb
@@ -121,7 +121,7 @@
    },
    "outputs": [],
    "source": [
-    "DATA_PATH = unzip_url(Urls.fridge_objects_path, exist_ok=True)\n",
+    "DATA_PATH = str(Path(unzip_url(Urls.fridge_objects_path, exist_ok=True)) / \"fridgeObjects\")\n",
     "\n",
     "# Number of negative samples to add for each iteration of negative mining\n",
     "NEGATIVE_NUM = 10\n",
@@ -192,7 +192,7 @@
    ],
    "source": [
     "ori_datapath = Path(DATA_PATH)\n",
-    "neg_datapath = Path(unzip_url(Urls.fridge_objects_negatives_path, exist_ok=True))\n",
+    "neg_datapath = Path(unzip_url(Urls.fridge_objects_negatives_path, exist_ok=True)) / \"fridgeObjectsNegative\"\n",
     "# We split positive samples into 80% training and 20% validation\n",
     "data_imlist = (\n",
     "    ImageList.from_folder(ori_datapath)\n",

--- a/scenarios/classification/24_exploring_hyperparameters_on_azureml.ipynb
+++ b/scenarios/classification/24_exploring_hyperparameters_on_azureml.ipynb
@@ -122,7 +122,7 @@
     "MAX_TOTAL_RUNS = 10 #Set to higher value to test more parameter combinations\n",
     "\n",
     "# Image data\n",
-    "DATA = unzip_url(Urls.fridge_objects_path, exist_ok=True)"
+    "DATA = str(Path(unzip_url(Urls.fridge_objects_path, exist_ok=True)) / \"fridgeObjects\")"
    ]
   },
   {

--- a/scenarios/detection/01_training_introduction.ipynb
+++ b/scenarios/detection/01_training_introduction.ipynb
@@ -129,7 +129,7 @@
     }
    ],
    "source": [
-    "DATA_PATH = unzip_url(Urls.fridge_objects_path, exist_ok=True)\n",
+    "DATA_PATH = str(Path(unzip_url(Urls.fridge_objects_path, exist_ok=True)) / \"odFridgeObjects\")\n",
     "EPOCHS = 10\n",
     "LEARNING_RATE = 0.005\n",
     "IM_SIZE = 500\n",

--- a/scenarios/detection/11_exploring_hyperparameters_on_azureml.ipynb
+++ b/scenarios/detection/11_exploring_hyperparameters_on_azureml.ipynb
@@ -123,7 +123,7 @@
     "LEARNING_RATES = [1e-4, 3e-4, 1e-3, 3e-3, 1e-2]\n",
     "\n",
     "# Image data\n",
-    "DATA_PATH = unzip_url(Urls.fridge_objects_path, exist_ok=True)\n",
+    "DATA_PATH = str(Path(unzip_url(Urls.fridge_objects_path, exist_ok=True)) / \"odFridgeObjects\")\n",
     "\n",
     "# Path to utils_cv library\n",
     "UTILS_DIR = os.path.join('..', '..', 'utils_cv')"

--- a/scenarios/similarity/00_webcam.ipynb
+++ b/scenarios/similarity/00_webcam.ipynb
@@ -132,7 +132,7 @@
     "IM_SIZE = 300  # image size in pixels. Reduce to speed-up demo.\n",
     "\n",
     "# Set path to query and reference images\n",
-    "im_path = unzip_url(Urls.fridge_objects_path, exist_ok=True)\n",
+    "im_path = str(Path(unzip_url(Urls.fridge_objects_path, exist_ok=True)) / \"fridgeObjects\")\n",
     "ref_im_path = os.path.join(Path(im_path) / \"can\")\n",
     "query_im_path = os.path.join(Path(im_path) / \"can\" / \"1.jpg\")\n",
     "print(f\"Query image path = {query_im_path}\")\n",

--- a/scenarios/similarity/01_training_and_evaluation_introduction.ipynb
+++ b/scenarios/similarity/01_training_and_evaluation_introduction.ipynb
@@ -138,7 +138,7 @@
    "outputs": [],
    "source": [
     "# Set dataset, model and evaluation parameters\n",
-    "DATA_PATH = unzip_url(Urls.fridge_objects_path, exist_ok=True)\n",
+    "DATA_PATH = str(Path(unzip_url(Urls.fridge_objects_path, exist_ok=True)) / \"fridgeObjects\")\n",
     "\n",
     "# DNN configuration and learning parameters\n",
     "EPOCHS_HEAD = 4\n",

--- a/scenarios/similarity/11_exploring_hyperparameters.ipynb
+++ b/scenarios/similarity/11_exploring_hyperparameters.ipynb
@@ -109,7 +109,7 @@
    },
    "outputs": [],
    "source": [
-    "DATA_PATHS = [unzip_url(Urls.fridge_objects_path, exist_ok=True), unzip_url(Urls.fridge_objects_watermark_path, exist_ok=True)]\n",
+    "DATA_PATHS = [str(Path(unzip_url(Urls.fridge_objects_path, exist_ok=True)) / \"fridgeObjects\"), str(Path(unzip_url(Urls.fridge_objects_watermark_path, exist_ok=True)) / \"fridgeObjectsWatermark\")]\n",
     "REPS = 3\n",
     "LEARNING_RATES = [1e-3, 1e-4, 1e-5]\n",
     "IM_SIZES = [300, 500]\n",

--- a/scenarios/similarity/12_fast_retrieval.ipynb
+++ b/scenarios/similarity/12_fast_retrieval.ipynb
@@ -113,7 +113,7 @@
    "outputs": [],
    "source": [
     "# Data location\n",
-    "DATA_PATH = unzip_url(Urls.fridge_objects_path, exist_ok=True)\n",
+    "DATA_PATH = str(Path(unzip_url(Urls.fridge_objects_path, exist_ok=True)) / \"fridgeObjects\")\n",
     "\n",
     "# Image reader configuration\n",
     "BATCH_SIZE = 16\n",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,12 +164,12 @@ def tmp(tmp_path_factory):
 @pytest.fixture(scope="function")
 def func_tiny_od_data_path(tmp_session) -> str:
     """ Returns the path to the fridge object detection dataset. """
-    return unzip_url(
+    return str(Path(unzip_url(
         od_urls.fridge_objects_tiny_path,
         fpath=f"{tmp_session}/tmp",
         dest=f"{tmp_session}/tmp",
         exist_ok=True,
-    )
+    )) / "odFridgeObjectsTiny")
 
 
 # ----- Session fixtures ----------------------------------------------------------
@@ -189,63 +189,63 @@ def tmp_session(tmp_path_factory):
 def tiny_ic_multidata_path(tmp_session) -> List[str]:
     """ Returns the path to multiple dataset. """
     return [
-        unzip_url(
+        str(Path(unzip_url(
             ic_urls.fridge_objects_watermark_tiny_path,
             fpath=tmp_session,
             dest=tmp_session,
             exist_ok=True,
-        ),
-        unzip_url(
+        )) / "fridgeObjectsWatermarkTiny"),
+        str(Path(unzip_url(
             ic_urls.fridge_objects_tiny_path,
             fpath=tmp_session,
             dest=tmp_session,
             exist_ok=True,
-        ),
+        )) / "fridgeObjectsTiny"),
     ]
 
 
 @pytest.fixture(scope="session")
 def tiny_ic_data_path(tmp_session) -> str:
     """ Returns the path to the tiny fridge objects dataset. """
-    return unzip_url(
+    return str(Path(unzip_url(
         ic_urls.fridge_objects_tiny_path,
         fpath=tmp_session,
         dest=tmp_session,
         exist_ok=True,
-    )
+    )) / "fridgeObjectsTiny")
 
 
 @pytest.fixture(scope="session")
 def tiny_multilabel_ic_data_path(tmp_session) -> str:
     """ Returns the path to the tiny fridge objects dataset. """
-    return unzip_url(
+    return str(Path(unzip_url(
         ic_urls.multilabel_fridge_objects_tiny_path,
         fpath=tmp_session,
         dest=tmp_session,
         exist_ok=True,
-    )
+    )) / "multilabelFridgeObjectsTiny")
 
 
 @pytest.fixture(scope="session")
 def multilabel_ic_data_path(tmp_session) -> str:
     """ Returns the path to the tiny fridge objects dataset. """
-    return unzip_url(
+    return str(Path(unzip_url(
         ic_urls.multilabel_fridge_objects_path,
         fpath=tmp_session,
         dest=tmp_session,
         exist_ok=True,
-    )
+    )) / "multilabelFridgeObjects")
 
 
 @pytest.fixture(scope="session")
 def tiny_ic_databunch(tmp_session):
     """ Returns a databunch object for the tiny fridge objects dataset. """
-    im_paths = unzip_url(
+    im_paths = str(Path(unzip_url(
         ic_urls.fridge_objects_tiny_path,
         fpath=tmp_session,
         dest=tmp_session,
         exist_ok=True,
-    )
+    )) / "fridgeObjectsTiny")
     return (
         ImageList.from_folder(im_paths)
         .split_by_rand_pct(valid_pct=0.1, seed=20)
@@ -289,12 +289,12 @@ def model_pred_scores(tiny_ic_databunch):
 def testing_im_list(tmp_session):
     """ Set of 5 images from the can/ folder of the Fridge Objects dataset
      used to test positive example rank calculations"""
-    im_paths = unzip_url(
+    im_paths = str(Path(unzip_url(
         ic_urls.fridge_objects_tiny_path,
         fpath=tmp_session,
         dest=tmp_session,
         exist_ok=True,
-    )
+    )) / "fridgeObjectsTiny")
     can_im_paths = os.listdir(os.path.join(im_paths, "can"))
     can_im_paths = [
         os.path.join(im_paths, "can", im_name) for im_name in can_im_paths
@@ -307,12 +307,12 @@ def testing_databunch(tmp_session):
     """ Builds a databunch from the Fridge Objects
     and returns its validation component that is used
     to test comparative_set_builder"""
-    im_paths = unzip_url(
+    im_paths = str(Path(unzip_url(
         ic_urls.fridge_objects_tiny_path,
         fpath=tmp_session,
         dest=tmp_session,
         exist_ok=True,
-    )
+    )) / "fridgeObjectsTiny")
     can_im_paths = os.listdir(os.path.join(im_paths, "can"))
     can_im_paths = [
         os.path.join(im_paths, "can", im_name) for im_name in can_im_paths
@@ -378,12 +378,12 @@ def od_cup_det_bboxes(tmp_session, od_cup_path) -> List[DetectionBbox]:
 @pytest.fixture(scope="session")
 def tiny_od_data_path(tmp_session) -> str:
     """ Returns the path to the fridge object detection dataset. """
-    return unzip_url(
+    return str(Path(unzip_url(
         od_urls.fridge_objects_tiny_path,
         fpath=tmp_session,
         dest=tmp_session,
         exist_ok=True,
-    )
+    )) / "odFridgeObjectsTiny")
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/common/test_common_data.py
+++ b/tests/unit/common/test_common_data.py
@@ -99,7 +99,7 @@ def test_unzip_url_exist_ok(tmp_path):
         exist_ok=True,
     )
     # should unzip all four data class directories
-    assert len(os.listdir(fridge_object_path)) == 4
+    assert len(os.listdir(str(Path(fridge_object_path) / "fridgeObjectsWatermark"))) == 4
 
 
 def test_unzip_url_not_exist_ok(tmp_path):
@@ -123,7 +123,7 @@ def test_unzip_url_not_exist_ok(tmp_path):
     )
 
     # should unzip all four data class directories
-    assert len(os.listdir(fridge_object_path)) == 4
+    assert len(os.listdir(str(Path(fridge_object_path) / "fridgeObjects"))) == 4
 
 
 def test_unzip_urls(tmp_path):

--- a/utils_cv/common/data.py
+++ b/utils_cv/common/data.py
@@ -104,7 +104,7 @@ def unzip_url(
         _raise_file_exists_error(unzipped_dir)
     else:
         z = ZipFile(zip_file, "r")
-        z.extractall(fpath)
+        z.extractall(unzipped_dir)
         z.close()
 
     return os.path.realpath(unzipped_dir)


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

The function `unzip_url()` is used to download a zip file to `fpath / zip file` and unzip it to `dest / zip file without extension`, so the correct parameter for `ZipFile.extratcall()` needs to be `dest / zip file without extension` which is `unzipped_dir` in the code instead of `fpath`.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.